### PR TITLE
feat: integrate docling context upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,33 @@ POST /agents/{agent_id}/ask
 ```
 
 As respostas ainda são simuladas, mas a estrutura está pronta para evolução com CrewAI e Docling.
+
+### Enviar arquivos de contexto para um agente
+
+```http
+POST /agents/{agent_id}/context
+Content-Type: multipart/form-data
+files: [planilha.xlsx, relatorio.pdf]
+```
+
+### Estrutura de agente com documentos associados
+
+```json
+{
+  "id": "123",
+  "name": "Finance Bot",
+  "description": "Auxilia na análise de planilhas",
+  "objective": "Responder dúvidas financeiras",
+  "context_files": ["planilha.xlsx", "relatorio.pdf"],
+  "context_docs": ["doc1", "doc2"]
+}
+```
+
+### Pergunta considerando o contexto
+
+```http
+POST /agents/{agent_id}/ask
+{
+  "question": "Liste os totais presentes na planilha"
+}
+```

--- a/backend/app/api/v1/agent_router.py
+++ b/backend/app/api/v1/agent_router.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, UploadFile, File
 
 from ...models.agent import Agent, AgentCreate
 from ...models.message import Question, Answer
+from ...models.document import Document
 from ...services.agent_service import AgentService
 
 router = APIRouter()
@@ -21,6 +22,15 @@ def get_agent(agent_id: str):
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     return agent
+
+
+@router.post("/{agent_id}/context", response_model=list[Document])
+def upload_context(agent_id: str, files: list[UploadFile] = File(...)):
+    try:
+        docs = service.add_context(agent_id, files)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return docs
 
 @router.post("/{agent_id}/ask", response_model=Answer)
 def ask_agent(agent_id: str, question: Question):

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -15,6 +15,7 @@ class Agent(BaseModel):
     description: str
     objective: str
     context_files: List[str] = []
+    context_docs: List[str] = []
 
     @classmethod
     def from_create(cls, data: AgentCreate) -> "Agent":

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from uuid import uuid4
+from typing import Any
 
 class DocumentCreate(BaseModel):
     name: str
-    content: str = ""
+    content: Any = None
 
 class Document(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     name: str
-    content: str = ""
+    content: Any = None
 
     @classmethod
     def from_create(cls, data: DocumentCreate) -> "Document":

--- a/backend/app/parsers/base_parser.py
+++ b/backend/app/parsers/base_parser.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from fastapi import UploadFile
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseParser(ABC):
+    """Base parser interface."""
+
+    @abstractmethod
+    def parse(self, file: UploadFile) -> Any:
+        """Parse an uploaded file and return structured content."""
+        raise NotImplementedError

--- a/backend/app/parsers/csv_parser.py
+++ b/backend/app/parsers/csv_parser.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pandas as pd
+from fastapi import UploadFile
+from typing import Any
+
+from .base_parser import BaseParser
+
+try:
+    from docling import Table
+except Exception:  # pragma: no cover
+    class Table:  # type: ignore
+        def __init__(self, data: Any) -> None:
+            self.data = data
+
+        def __repr__(self) -> str:
+            return f"Table(rows={len(self.data)})"
+
+
+class CSVParser(BaseParser):
+    """Parse .csv files into Docling Table structures."""
+
+    def parse(self, file: UploadFile) -> Any:
+        df = pd.read_csv(file.file)
+        return Table(df)

--- a/backend/app/parsers/excel_parser.py
+++ b/backend/app/parsers/excel_parser.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pandas as pd
+from fastapi import UploadFile
+from typing import Any
+
+from .base_parser import BaseParser
+
+try:
+    from docling import Table
+except Exception:  # pragma: no cover - Docling may not be installed
+    class Table:  # type: ignore
+        def __init__(self, data: Any) -> None:
+            self.data = data
+
+        def __repr__(self) -> str:  # pragma: no cover - simple representation
+            return f"Table(rows={len(self.data)})"
+
+
+class ExcelParser(BaseParser):
+    """Parse .xlsx files into Docling Table structures."""
+
+    def parse(self, file: UploadFile) -> Any:
+        df = pd.read_excel(file.file)
+        return Table(df)

--- a/backend/app/parsers/pdf_parser.py
+++ b/backend/app/parsers/pdf_parser.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import UploadFile
+from typing import Any, List
+
+from .base_parser import BaseParser
+
+try:
+    from docling import Text
+except Exception:  # pragma: no cover
+    class Text:  # type: ignore
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+        def __repr__(self) -> str:
+            return f"Text(len={len(self.content)})"
+
+
+class PDFParser(BaseParser):
+    """Parse .pdf files splitting content by pages."""
+
+    def parse(self, file: UploadFile) -> Any:
+        try:
+            from pdfminer.high_level import extract_text
+        except Exception:
+            # Fallback if pdfminer is not available
+            text = file.file.read().decode("utf-8", errors="ignore")
+        else:
+            text = extract_text(file.file)
+        pages = [Text(p.strip()) for p in text.split("\f") if p.strip()]
+        return pages


### PR DESCRIPTION
## Summary
- add Docling-based parsers for csv, xlsx and pdf
- store parsed documents in memory through `DocumentService`
- support uploading context files to agents
- teach `AgentService` to respond using uploaded context
- document context upload usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6865ed2751c08327a03d1e52efbe5356