### PR TITLE
Fix AgentsPage crash when API unavailable

### DIFF
--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -8,7 +8,11 @@ export default function AgentsPage() {
   const { agents, setAgents } = useStore()
 
   useEffect(() => {
-    listAgents().then(setAgents)
+    listAgents().then(data => {
+      if (Array.isArray(data)) {
+        setAgents(data)
+      }
+    })
   }, [setAgents])
 
   return (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,11 +8,23 @@ export interface Question {
   question: string;
 }
 
-const BASE_URL = '';
+// Base URL of the FastAPI server
+// During development the backend runs on port 8000
+// so we need to prefix requests accordingly.
+const BASE_URL = 'http://localhost:8000';
 
 export async function listAgents() {
-  const res = await fetch(`${BASE_URL}/agents`);
-  return res.json();
+  try {
+    const res = await fetch(`${BASE_URL}/agents`);
+    if (!res.ok) {
+      console.error('Failed to fetch agents', res.status);
+      return [];
+    }
+    return await res.json();
+  } catch (err) {
+    console.error('Error fetching agents', err);
+    return [];
+  }
 }
 
 export async function createAgent(data: AgentCreate) {


### PR DESCRIPTION
## Summary
- handle failed `/agents` requests and return an empty list
- guard AgentsPage state update and set only valid arrays
- configure API base URL to local backend port 8000

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx vitest run` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_687b08dc028c83279ba352ffcf4c1831