### PR TITLE
Fix Excel parser import

### DIFF
--- a/backend/app/parsers/excel_parser.py
+++ b/backend/app/parsers/excel_parser.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-import pandas as pd
+try:
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - pandas may not be installed
+    pd = None  # type: ignore
 from fastapi import UploadFile
 from typing import Any
 
@@ -23,5 +26,7 @@ class ExcelParser(BaseParser):
     """Parse .xlsx files into Docling Table structures."""
 
     def parse(self, file: UploadFile) -> Any:
+        if pd is None:  # pragma: no cover - handled when pandas is unavailable
+            raise RuntimeError("pandas is required to parse Excel files")
         df = pd.read_excel(file.file)
         return Table(df)


### PR DESCRIPTION
## Summary
- avoid crashing if pandas isn't installed by lazily importing it in Excel parser

## Testing
- `pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_687b0b6de9088327a73018edeb6dcd4d